### PR TITLE
docs: add local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # mmmines
+
+an endless, massive multiplayer minesweeper game built with Next.js, Socket.IO,
+and Redis.
+
+## run locally
+
+requires Node.js 20, npm, and Redis.
+
+```sh
+npm ci
+cp .env.sample .env.local
+```
+
+replace `REDIS_URL` in `.env.local` with:
+
+```dotenv
+REDIS_URL=redis://localhost:6379
+```
+
+start Redis:
+
+```sh
+redis-server --save '' --appendonly no
+```
+
+in another terminal, start the app:
+
+```sh
+npm run dev
+```
+
+open [http://localhost:3000](http://localhost:3000).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ and Redis.
 
 ## run locally
 
-requires Node.js 20, npm, and Redis.
+requires Node.js 20, npm, and either Redis or Docker.
 
 ```sh
 npm ci
@@ -18,10 +18,16 @@ replace `REDIS_URL` in `.env.local` with:
 REDIS_URL=redis://localhost:6379
 ```
 
-start Redis:
+start Redis directly:
 
 ```sh
 redis-server --save '' --appendonly no
+```
+
+or with Docker:
+
+```sh
+docker run --rm -p 6379:6379 redis:7-alpine
 ```
 
 in another terminal, start the app:


### PR DESCRIPTION
## summary

- document the Node.js 20 and npm prerequisites
- add install and environment setup steps
- show how to start disposable Redis directly or through Docker
- explain how to run the development server

## why

the README only named the project, so contributors had no local setup path. these instructions use a local Redis instance and do not require access to the private Fly.io database.

## impact

contributors can install dependencies and run mmmines at `http://localhost:3000` using either an installed Redis server or Docker.

## checks

- `npx prettier --check README.md`
- `git diff --check`
- verified the Docker CLI supports the documented `--rm` and `--publish` flags
- `npm run dev` against disposable local Redis; verified HTTP 200 from `http://localhost:3000`