### PR TITLE
build: move runtime to Node.js 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.10.0
+ARG NODE_VERSION=24.18.0
 FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="Next.js"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ and Redis.
 
 ## run locally
 
-requires Node.js 20, npm, and either Redis or Docker.
+requires Node.js 24, npm, and either Redis or Docker.
 
 ```sh
 npm ci

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ and Redis.
 
 ## run locally
 
-requires Node.js 24, npm, and either Redis or Docker.
+requires Node.js 24.18.0, npm, and either Redis or Docker.
 
 ```sh
 npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@tsconfig/next": "^2.0.3",
         "@tsconfig/strictest": "^2.0.5",
         "@types/lodash": "^4.17.6",
-        "@types/node": "^20",
+        "@types/node": "^24.13.3",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.4.20",
@@ -50,6 +50,9 @@
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2716,11 +2719,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -8896,9 +8900,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@tsconfig/next": "^2.0.3",
         "@tsconfig/strictest": "^2.0.5",
         "@types/lodash": "^4.17.6",
-        "@types/node": "^24.13.3",
+        "@types/node": "24.13.3",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.4.20",
@@ -50,9 +50,6 @@
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5"
-      },
-      "engines": {
-        "node": ">=24"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "mmmines",
   "private": true,
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "esrun --watch app/server.ts",
     "start": "NODE_ENV=production esrun app/server.ts",
@@ -38,7 +41,7 @@
     "@tsconfig/next": "^2.0.3",
     "@tsconfig/strictest": "^2.0.5",
     "@types/lodash": "^4.17.6",
-    "@types/node": "^20",
+    "@types/node": "^24.13.3",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "24.18.0",
-      "onFail": "error"
+      "version": "24.18.0"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "mmmines",
   "private": true,
-  "engines": {
-    "node": ">=24"
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "24.18.0",
+      "onFail": "error"
+    }
   },
   "scripts": {
     "dev": "esrun --watch app/server.ts",
@@ -41,7 +45,7 @@
     "@tsconfig/next": "^2.0.3",
     "@tsconfig/strictest": "^2.0.5",
     "@types/lodash": "^4.17.6",
-    "@types/node": "^24.13.3",
+    "@types/node": "24.13.3",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
## summary

- pin Node.js 24.18.0 across `devEngines`, the local setup docs, and the Docker image
- align `@types/node` with Node.js 24 and refresh the lockfile

## why

keeping the declared development runtime and container runtime on one exact version prevents environment drift.

## stack

this is the runtime foundation for the dependency-remediation stack. #44 builds on this PR.

## validation

- Fly review deployment
