### PR TITLE
ci: use upstream Fly review action

### DIFF
--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -1,6 +1,6 @@
 # see:
 # * https://fly.io/docs/blueprints/review-apps-guide
-# * https://github.com/superfly/fly-pr-review-apps/blob/1.2.1/README.md
+# * https://github.com/superfly/fly-pr-review-apps/blob/1.6.0/README.md
 
 name: Fly Review
 on:
@@ -28,8 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: deploy
-        uses: lewxdev/fly-pr-review-apps@main
+        uses: superfly/fly-pr-review-apps@1.6.0
         with:
+          name: ${{ env.FLY_APP }}
           build_secrets: BASE_URL=https://${{ env.FLY_APP }}.fly.dev
           secrets: |
             BASE_URL=https://${{ env.FLY_APP }}.fly.dev


### PR DESCRIPTION
## summary

- replace the deleted `lewxdev/fly-pr-review-apps` fork with upstream `superfly/fly-pr-review-apps@1.6.0`
- pass the existing `FLY_APP` value through the supported `name` input
- update the workflow's upstream documentation link

## why

Fly Review failed before checkout because GitHub could not resolve the deleted fork. the fork originally supplied build-secret support and an implicit `FLY_APP` fallback. upstream now supports build secrets, while the explicit `name` input preserves the existing `pr-<number>-mmmines` app name without fork-only behavior.

## impact

review deployments resolve the maintained upstream action again without changing their Fly app names, build secret, runtime secrets, organization, or region.

## checks

- parsed `.github/workflows/fly-review.yml` as YAML
- `prettier --no-config --check .github/workflows/fly-review.yml`
- `git diff --check`
- verified the upstream `1.6.0` tag resolves to commit `5d9f067254bebd0aaa77d908d6337b63f4d4f019`
- Fly Review run `31845916392` passed end to end
- `https://pr-50-mmmines.fly.dev` returned HTTP 200