### PR TITLE
feat: add navigable minimap for large minefields

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,6 @@
 BASE_URL=http://localhost:3000
+# optional: force the minefield dimensions in local development
+DEV_FIELD_SIZE=
 
 # redis
 REDIS_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ public/swe-worker*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# redis
+*.rdb

--- a/app/components/field.tsx
+++ b/app/components/field.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Fade } from "@/components/fade";
 import { GameOverDialog } from "@/components/game-over-dialog";
+import { Minimap } from "@/components/minimap";
 import { Plot } from "@/components/plot";
 import { TutorialDialog } from "@/components/tutorial-dialog";
 import { useSocketEvent } from "@/hooks/use-socket-event";
@@ -64,37 +65,40 @@ export function Field() {
       </div>
     </div>
   ) : (
-    <div
-      className="max-w-full flex-1 select-none overflow-auto"
-      onContextMenu={(event) => event.preventDefault()}
-      ref={parentRef}
-    >
+    <div className="relative min-h-0 w-[min(var(--field-size),100%)] flex-1">
       <div
-        className="relative"
-        style={{
-          height: rowVirtualizer.getTotalSize(),
-          width: columnVirtualizer.getTotalSize(),
-        }}
+        className="h-full max-w-full select-none overflow-auto"
+        onContextMenu={(event) => event.preventDefault()}
+        ref={parentRef}
       >
-        {rowVirtualizer.getVirtualItems().flatMap((virtualRow) =>
-          columnVirtualizer.getVirtualItems().map((virtualColumn) => {
-            const { index: y, size: height, start: top } = virtualRow;
-            const { index: x, size: width, start: left } = virtualColumn;
-            const index = y * size + x;
-            return (
-              // todo: add room/mode to key
-              <Fade key={`${size}:${index}`}>
-                <Plot
-                  className="absolute"
-                  index={index}
-                  state={plots[index]!}
-                  style={{ height, width, top, left }}
-                />
-              </Fade>
-            );
-          }),
-        )}
+        <div
+          className="relative"
+          style={{
+            height: rowVirtualizer.getTotalSize(),
+            width: columnVirtualizer.getTotalSize(),
+          }}
+        >
+          {rowVirtualizer.getVirtualItems().flatMap((virtualRow) =>
+            columnVirtualizer.getVirtualItems().map((virtualColumn) => {
+              const { index: y, size: height, start: top } = virtualRow;
+              const { index: x, size: width, start: left } = virtualColumn;
+              const index = y * size + x;
+              return (
+                // todo: add room/mode to key
+                <Fade key={`${size}:${index}`}>
+                  <Plot
+                    className="absolute"
+                    index={index}
+                    state={plots[index]!}
+                    style={{ height, width, top, left }}
+                  />
+                </Fade>
+              );
+            }),
+          )}
+        </div>
       </div>
+      <Minimap plots={plots} scrollRef={parentRef} />
       {sessionState === "dead" && <GameOverDialog />}
       {isNewSession && <TutorialDialog />}
     </div>

--- a/app/components/minimap.tsx
+++ b/app/components/minimap.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { PlotState } from "@/utils/game";
+
+type Props = {
+  plots: PlotState[];
+  scrollRef: React.RefObject<HTMLDivElement>;
+};
+
+type Viewport = {
+  clientHeight: number;
+  clientWidth: number;
+  scrollHeight: number;
+  scrollLeft: number;
+  scrollTop: number;
+  scrollWidth: number;
+};
+
+const EMPTY_VIEWPORT: Viewport = {
+  clientHeight: 0,
+  clientWidth: 0,
+  scrollHeight: 0,
+  scrollLeft: 0,
+  scrollTop: 0,
+  scrollWidth: 0,
+};
+
+const palettes = {
+  dark: {
+    background: "#020617",
+    flagged: "#fde047",
+    mine: "#f87171",
+    numbered: "#94a3b8",
+    unknown: "#475569",
+    viewport: "#f8fafc",
+    viewportFill: "rgba(248, 250, 252, 0.08)",
+  },
+  light: {
+    background: "#ffffff",
+    flagged: "#facc15",
+    mine: "#ef4444",
+    numbered: "#64748b",
+    unknown: "#e2e8f0",
+    viewport: "#0f172a",
+    viewportFill: "rgba(15, 23, 42, 0.06)",
+  },
+};
+
+export function Minimap({ plots, scrollRef }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [viewport, setViewport] = useState(EMPTY_VIEWPORT);
+  const [isDark, setIsDark] = useState(false);
+  const size = Math.sqrt(plots.length);
+  const isScrollable =
+    viewport.scrollWidth > viewport.clientWidth + 1 ||
+    viewport.scrollHeight > viewport.clientHeight + 1;
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) return;
+
+    let animationFrame: number | undefined;
+    const updateViewport = () => {
+      if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(() => {
+        setViewport({
+          clientHeight: scrollElement.clientHeight,
+          clientWidth: scrollElement.clientWidth,
+          scrollHeight: scrollElement.scrollHeight,
+          scrollLeft: scrollElement.scrollLeft,
+          scrollTop: scrollElement.scrollTop,
+          scrollWidth: scrollElement.scrollWidth,
+        });
+      });
+    };
+
+    const resizeObserver = new ResizeObserver(updateViewport);
+    resizeObserver.observe(scrollElement);
+    if (scrollElement.firstElementChild instanceof HTMLElement) {
+      resizeObserver.observe(scrollElement.firstElementChild);
+    }
+    scrollElement.addEventListener("scroll", updateViewport, {
+      passive: true,
+    });
+    updateViewport();
+
+    return () => {
+      if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
+      resizeObserver.disconnect();
+      scrollElement.removeEventListener("scroll", updateViewport);
+    };
+  }, [plots.length, scrollRef]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const updateTheme = () => setIsDark(root.classList.contains("dark"));
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(root, { attributeFilter: ["class"], attributes: true });
+    updateTheme();
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !isScrollable || !Number.isInteger(size)) return;
+
+    const bounds = canvas.getBoundingClientRect();
+    const pixelRatio = window.devicePixelRatio || 1;
+    canvas.width = Math.round(bounds.width * pixelRatio);
+    canvas.height = Math.round(bounds.height * pixelRatio);
+
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    context.scale(pixelRatio, pixelRatio);
+
+    const palette = isDark ? palettes.dark : palettes.light;
+    context.fillStyle = palette.background;
+    context.fillRect(0, 0, bounds.width, bounds.height);
+
+    const cellWidth = bounds.width / size;
+    const cellHeight = bounds.height / size;
+    const inset = Math.min(0.5, cellWidth * 0.08, cellHeight * 0.08);
+
+    plots.forEach((state, index) => {
+      if (state === 0) return;
+
+      if (state === "unknown") context.fillStyle = palette.unknown;
+      else if (state === "flagged") context.fillStyle = palette.flagged;
+      else if (state === "mine") context.fillStyle = palette.mine;
+      else context.fillStyle = palette.numbered;
+
+      context.globalAlpha = typeof state === "number" ? 0.2 + state * 0.08 : 1;
+      context.fillRect(
+        (index % size) * cellWidth + inset,
+        Math.floor(index / size) * cellHeight + inset,
+        Math.max(0.5, cellWidth - inset * 2),
+        Math.max(0.5, cellHeight - inset * 2),
+      );
+    });
+    context.globalAlpha = 1;
+
+    const viewportX =
+      (viewport.scrollLeft / viewport.scrollWidth) * bounds.width;
+    const viewportY =
+      (viewport.scrollTop / viewport.scrollHeight) * bounds.height;
+    const viewportWidth =
+      (viewport.clientWidth / viewport.scrollWidth) * bounds.width;
+    const viewportHeight =
+      (viewport.clientHeight / viewport.scrollHeight) * bounds.height;
+
+    context.fillStyle = palette.viewportFill;
+    context.fillRect(viewportX, viewportY, viewportWidth, viewportHeight);
+    context.strokeStyle = palette.viewport;
+    context.lineWidth = 1.5;
+    context.strokeRect(
+      viewportX + 0.75,
+      viewportY + 0.75,
+      Math.max(0, viewportWidth - 1.5),
+      Math.max(0, viewportHeight - 1.5),
+    );
+  }, [isDark, isScrollable, plots, size, viewport]);
+
+  const navigateToPointer = useCallback(
+    (clientX: number, clientY: number) => {
+      const canvas = canvasRef.current;
+      const scrollElement = scrollRef.current;
+      if (!canvas || !scrollElement) return;
+
+      const bounds = canvas.getBoundingClientRect();
+      const x = (clientX - bounds.left) / bounds.width;
+      const y = (clientY - bounds.top) / bounds.height;
+      scrollElement.scrollTo({
+        left: x * scrollElement.scrollWidth - scrollElement.clientWidth / 2,
+        top: y * scrollElement.scrollHeight - scrollElement.clientHeight / 2,
+      });
+    },
+    [scrollRef],
+  );
+
+  if (!isScrollable) return null;
+
+  return (
+    <button
+      aria-label="Minefield minimap. Drag to navigate or use the arrow keys to pan."
+      className="absolute bottom-3 right-3 z-20 h-[clamp(6rem,18vw,9rem)] w-[clamp(6rem,18vw,9rem)] touch-none border border-slate-950/10 bg-white/90 p-1.5 shadow-sm backdrop-blur-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2 dark:border-white/15 dark:bg-slate-950/90 dark:focus-visible:ring-slate-100 dark:focus-visible:ring-offset-slate-950 sm:bottom-4 sm:right-4"
+      onKeyDown={(event) => {
+        const scrollElement = scrollRef.current;
+        if (!scrollElement) return;
+
+        const distanceX = scrollElement.clientWidth * 0.75;
+        const distanceY = scrollElement.clientHeight * 0.75;
+        const offsets = {
+          ArrowDown: [0, distanceY],
+          ArrowLeft: [-distanceX, 0],
+          ArrowRight: [distanceX, 0],
+          ArrowUp: [0, -distanceY],
+        } as const;
+        const offset = offsets[event.key as keyof typeof offsets];
+        if (!offset) return;
+        event.preventDefault();
+        scrollElement.scrollBy({
+          behavior: "smooth",
+          left: offset[0],
+          top: offset[1],
+        });
+      }}
+      onPointerDown={(event) => {
+        event.currentTarget.setPointerCapture(event.pointerId);
+        navigateToPointer(event.clientX, event.clientY);
+      }}
+      onPointerMove={(event) => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          navigateToPointer(event.clientX, event.clientY);
+        }
+      }}
+      type="button"
+    >
+      <canvas className="block h-full w-full" ref={canvasRef} />
+    </button>
+  );
+}

--- a/app/components/minimap.tsx
+++ b/app/components/minimap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTheme } from "next-themes";
 import type { PlotState } from "@/utils/game";
 
 type Props = {
@@ -50,7 +51,8 @@ const palettes = {
 export function Minimap({ plots, scrollRef }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [viewport, setViewport] = useState(EMPTY_VIEWPORT);
-  const [isDark, setIsDark] = useState(false);
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   const size = Math.sqrt(plots.length);
   const isScrollable =
     viewport.scrollWidth > viewport.clientWidth + 1 ||
@@ -91,15 +93,6 @@ export function Minimap({ plots, scrollRef }: Props) {
       scrollElement.removeEventListener("scroll", updateViewport);
     };
   }, [plots.length, scrollRef]);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    const updateTheme = () => setIsDark(root.classList.contains("dark"));
-    const observer = new MutationObserver(updateTheme);
-    observer.observe(root, { attributeFilter: ["class"], attributes: true });
-    updateTheme();
-    return () => observer.disconnect();
-  }, []);
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/app/components/minimap.tsx
+++ b/app/components/minimap.tsx
@@ -18,6 +18,12 @@ type Viewport = {
   scrollWidth: number;
 };
 
+type CanvasSize = {
+  height: number;
+  pixelRatio: number;
+  width: number;
+};
+
 const EMPTY_VIEWPORT: Viewport = {
   clientHeight: 0,
   clientWidth: 0,
@@ -27,6 +33,12 @@ const EMPTY_VIEWPORT: Viewport = {
   scrollWidth: 0,
 };
 
+const EMPTY_CANVAS_SIZE: CanvasSize = {
+  height: 0,
+  pixelRatio: 1,
+  width: 0,
+};
+
 const palettes = {
   dark: {
     background: "#020617",
@@ -34,8 +46,6 @@ const palettes = {
     mine: "#f87171",
     numbered: "#94a3b8",
     unknown: "#475569",
-    viewport: "#f8fafc",
-    viewportFill: "rgba(248, 250, 252, 0.08)",
   },
   light: {
     background: "#ffffff",
@@ -43,13 +53,12 @@ const palettes = {
     mine: "#ef4444",
     numbered: "#64748b",
     unknown: "#e2e8f0",
-    viewport: "#0f172a",
-    viewportFill: "rgba(15, 23, 42, 0.06)",
   },
 };
 
 export function Minimap({ plots, scrollRef }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [canvasSize, setCanvasSize] = useState(EMPTY_CANVAS_SIZE);
   const [viewport, setViewport] = useState(EMPTY_VIEWPORT);
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
@@ -96,23 +105,59 @@ export function Minimap({ plots, scrollRef }: Props) {
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas || !isScrollable || !Number.isInteger(size)) return;
+    if (!canvas || !isScrollable) return;
 
-    const bounds = canvas.getBoundingClientRect();
-    const pixelRatio = window.devicePixelRatio || 1;
-    canvas.width = Math.round(bounds.width * pixelRatio);
-    canvas.height = Math.round(bounds.height * pixelRatio);
+    const updateCanvasSize = () => {
+      const bounds = canvas.getBoundingClientRect();
+      const nextSize = {
+        height: bounds.height,
+        pixelRatio: window.devicePixelRatio || 1,
+        width: bounds.width,
+      };
+      setCanvasSize((currentSize) =>
+        currentSize.height === nextSize.height &&
+        currentSize.pixelRatio === nextSize.pixelRatio &&
+        currentSize.width === nextSize.width
+          ? currentSize
+          : nextSize,
+      );
+    };
+
+    const resizeObserver = new ResizeObserver(updateCanvasSize);
+    resizeObserver.observe(canvas);
+    window.addEventListener("resize", updateCanvasSize);
+    updateCanvasSize();
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", updateCanvasSize);
+    };
+  }, [isScrollable]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (
+      !canvas ||
+      !canvasSize.height ||
+      !canvasSize.width ||
+      !Number.isInteger(size)
+    ) {
+      return;
+    }
+
+    canvas.width = Math.round(canvasSize.width * canvasSize.pixelRatio);
+    canvas.height = Math.round(canvasSize.height * canvasSize.pixelRatio);
 
     const context = canvas.getContext("2d");
     if (!context) return;
-    context.scale(pixelRatio, pixelRatio);
+    context.scale(canvasSize.pixelRatio, canvasSize.pixelRatio);
 
     const palette = isDark ? palettes.dark : palettes.light;
     context.fillStyle = palette.background;
-    context.fillRect(0, 0, bounds.width, bounds.height);
+    context.fillRect(0, 0, canvasSize.width, canvasSize.height);
 
-    const cellWidth = bounds.width / size;
-    const cellHeight = bounds.height / size;
+    const cellWidth = canvasSize.width / size;
+    const cellHeight = canvasSize.height / size;
     const inset = Math.min(0.5, cellWidth * 0.08, cellHeight * 0.08);
 
     plots.forEach((state, index) => {
@@ -132,27 +177,7 @@ export function Minimap({ plots, scrollRef }: Props) {
       );
     });
     context.globalAlpha = 1;
-
-    const viewportX =
-      (viewport.scrollLeft / viewport.scrollWidth) * bounds.width;
-    const viewportY =
-      (viewport.scrollTop / viewport.scrollHeight) * bounds.height;
-    const viewportWidth =
-      (viewport.clientWidth / viewport.scrollWidth) * bounds.width;
-    const viewportHeight =
-      (viewport.clientHeight / viewport.scrollHeight) * bounds.height;
-
-    context.fillStyle = palette.viewportFill;
-    context.fillRect(viewportX, viewportY, viewportWidth, viewportHeight);
-    context.strokeStyle = palette.viewport;
-    context.lineWidth = 1.5;
-    context.strokeRect(
-      viewportX + 0.75,
-      viewportY + 0.75,
-      Math.max(0, viewportWidth - 1.5),
-      Math.max(0, viewportHeight - 1.5),
-    );
-  }, [isDark, isScrollable, plots, size, viewport]);
+  }, [canvasSize, isDark, isScrollable, plots, size]);
 
   const navigateToPointer = useCallback(
     (clientX: number, clientY: number) => {
@@ -172,6 +197,13 @@ export function Minimap({ plots, scrollRef }: Props) {
   );
 
   if (!isScrollable) return null;
+
+  const viewportStyle = {
+    height: `${(viewport.clientHeight / viewport.scrollHeight) * 100}%`,
+    left: `${(viewport.scrollLeft / viewport.scrollWidth) * 100}%`,
+    top: `${(viewport.scrollTop / viewport.scrollHeight) * 100}%`,
+    width: `${(viewport.clientWidth / viewport.scrollWidth) * 100}%`,
+  };
 
   return (
     <button
@@ -209,7 +241,17 @@ export function Minimap({ plots, scrollRef }: Props) {
       }}
       type="button"
     >
-      <canvas className="block h-full w-full" ref={canvasRef} />
+      <span className="relative block h-full w-full">
+        <canvas
+          className="absolute inset-0 block h-full w-full"
+          ref={canvasRef}
+        />
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute box-border border-[1.5px] border-slate-900 bg-slate-900/5 dark:border-slate-50 dark:bg-slate-50/10"
+          style={viewportStyle}
+        />
+      </span>
     </button>
   );
 }

--- a/app/server.ts
+++ b/app/server.ts
@@ -12,9 +12,10 @@ const port = 3000;
 async function main() {
   const app = next({ dev, hostname, port });
   await app.prepare();
+  const devFieldSize = getDevFieldSize();
   const httpServer = createServer(app.getRequestHandler());
   const io: SocketServer = new Server(httpServer);
-  let field = await Field.fromRedis();
+  let field = await Field.fromRedis(devFieldSize);
 
   // middleware on incoming connection (see: https://socket.io/docs/v4/server-api/#serverusefn)
   // handles "authentication" and manages *initial* session data
@@ -56,7 +57,7 @@ async function main() {
         // update session state and emit to client
         socket.emit("sessionState", (socket.data.sessionState = "dead"));
       } else if (field.isComplete) {
-        field = await Field.create(field.size + 10);
+        field = await Field.create(devFieldSize ?? field.size + 10);
         await redis.resetSessions();
         // everyone is alive again 🎉
         io.emit("sessionState", "alive");
@@ -79,6 +80,19 @@ async function main() {
   httpServer.once("error", onError).listen(port, () => {
     console.log(`> Ready on http://${hostname}:${port}`);
   });
+}
+
+function getDevFieldSize() {
+  const value = process.env["DEV_FIELD_SIZE"];
+  if (!dev || value === undefined || value.trim() === "") {
+    return undefined;
+  }
+
+  const size = Number(value);
+  if (!Number.isSafeInteger(size) || size < 1) {
+    throw new Error("DEV_FIELD_SIZE must be a positive integer");
+  }
+  return size;
 }
 
 main().catch(onError);

--- a/app/utils/game.ts
+++ b/app/utils/game.ts
@@ -46,19 +46,22 @@ export class Field {
     return new Field(size, mineCount, data);
   }
 
-  public static async fromRedis() {
+  public static async fromRedis(forcedSize?: number) {
     try {
       const data = await redis.decodeData();
       const size = Math.sqrt(data.length);
+      if (forcedSize !== undefined && size !== forcedSize) {
+        return Field.create(forcedSize);
+      }
       const mineCount = _.sum(data.map(isMine));
       const exposedCount = data.reduce(
         (count, byte) => (isExposed(byte) && !isMine(byte) ? count + 1 : count),
         0,
       );
       const field = new Field(size, mineCount, data, exposedCount);
-      return field.isComplete ? Field.create(size + 10) : field;
+      return field.isComplete ? Field.create(forcedSize ?? size + 10) : field;
     } catch {
-      return Field.create();
+      return Field.create(forcedSize);
     }
   }
 


### PR DESCRIPTION
## Summary

- Add a responsive minimap for large, scrollable minefields
- Render minefield state with light/dark theme palettes and viewport tracking
- Support pointer navigation and keyboard arrow-key panning
- Add configurable development field sizes via `DEV_FIELD_SIZE`
- Ignore Redis dump files in Git

## Testing

Not run (not requested)