### PR TITLE
fix: restore Fly deployment

### DIFF
--- a/app/components/minimap.tsx
+++ b/app/components/minimap.tsx
@@ -6,7 +6,7 @@ import type { PlotState } from "@/utils/game";
 
 type Props = {
   plots: PlotState[];
-  scrollRef: React.RefObject<HTMLDivElement>;
+  scrollRef: React.RefObject<HTMLDivElement | null>;
 };
 
 type Viewport = {

--- a/app/server.ts
+++ b/app/server.ts
@@ -6,7 +6,7 @@ import { Field } from "@/utils/game";
 import * as redis from "@/utils/redis";
 
 const dev = process.env.NODE_ENV !== "production";
-const hostname = "localhost";
+const hostname = "0.0.0.0";
 const port = 3000;
 
 async function main() {
@@ -77,7 +77,7 @@ async function main() {
     });
   });
 
-  httpServer.once("error", onError).listen(port, () => {
+  httpServer.once("error", onError).listen(port, hostname, () => {
     console.log(`> Ready on http://${hostname}:${port}`);
   });
 }


### PR DESCRIPTION
## what changed

- accept React 19's nullable scroll element ref in the minimap
- bind the HTTP server explicitly to `0.0.0.0:3000`

## why

the latest Fly deployment was blocked by a TypeScript error in the new minimap. the running release also reported a misleading `localhost` address even though Fly requires a wildcard listener.

## impact

the production image can build again, and the server's configured address now matches Fly's routing contract.

## validation

- `BASE_URL=https://mmmines.fly.dev npm run build`
- `npm run lint`
- `git diff --check`